### PR TITLE
Fix session cleanup and async handling in transcription engine

### DIFF
--- a/Tome/Sources/Tome/Audio/MicCapture.swift
+++ b/Tome/Sources/Tome/Audio/MicCapture.swift
@@ -78,12 +78,6 @@ final class MicCapture: @unchecked Sendable {
 
             diagLog("[MIC-5] tap installed, preparing engine...")
 
-            continuation.onTermination = { [engine] _ in
-                diagLog("[MIC-TERM] stream terminated, stopping engine")
-                engine.inputNode.removeTap(onBus: 0)
-                engine.stop()
-            }
-
             do {
                 self.engine.prepare()
                 diagLog("[MIC-7] engine prepared, starting...")

--- a/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
+++ b/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
@@ -279,7 +279,7 @@ final class TranscriptionEngine {
         }
     }
 
-    func stop() {
+    func stop() async {
         removeDefaultDeviceListener()
         micTask?.cancel()
         sysTask?.cancel()
@@ -287,7 +287,7 @@ final class TranscriptionEngine {
         micTask = nil
         sysTask = nil
         micKeepAliveTask = nil
-        Task { await systemCapture.stop() }
+        await systemCapture.stop()
         micCapture.stop()
         currentMicDeviceID = 0
         isRunning = false

--- a/Tome/Sources/Tome/Views/ContentView.swift
+++ b/Tome/Sources/Tome/Views/ContentView.swift
@@ -213,9 +213,12 @@ struct ContentView: View {
 
     private func stopSession() {
         let wasCallCapture = activeSessionType == .callCapture
+        activeSessionType = nil
+        detectedAppName = nil
+        silenceSeconds = 0
 
-        transcriptionEngine?.stop()
         Task {
+            await transcriptionEngine?.stop()
             await sessionStore.endSession()
             await transcriptLogger.endSession()
 
@@ -229,9 +232,6 @@ struct ContentView: View {
             // Finalize frontmatter AFTER diarization (duration, speakers, rename)
             await transcriptLogger.finalizeFrontmatter()
         }
-        activeSessionType = nil
-        detectedAppName = nil
-        silenceSeconds = 0
     }
 
     private func handleNewUtterance() {


### PR DESCRIPTION
## Summary
This PR fixes several issues related to session cleanup and async/await handling in the transcription engine to ensure proper resource cleanup and prevent race conditions.

## Key Changes

- **ContentView.stopSession()**: Reorganized cleanup logic to reset UI state (`activeSessionType`, `detectedAppName`, `silenceSeconds`) immediately before async operations, ensuring the UI reflects the stopped state right away. Moved the async `transcriptionEngine?.stop()` call into the Task block to properly await it.

- **TranscriptionEngine.stop()**: Changed from synchronous to async function and updated the `systemCapture.stop()` call to use `await` directly instead of wrapping it in a separate Task. This ensures proper sequencing of cleanup operations.

- **MicCapture**: Removed the `continuation.onTermination` handler that was attempting to stop the audio engine. This cleanup is now handled explicitly through the `stop()` method call, preventing potential race conditions and double-cleanup scenarios.

## Implementation Details

These changes ensure that:
1. UI state is updated immediately when stopping a session, providing better user feedback
2. Async operations are properly awaited in the correct order
3. Resource cleanup (audio engine, tasks) happens in a controlled manner without race conditions
4. The termination handler doesn't interfere with explicit cleanup calls