### PR TITLE
Add error visibility, save confirmation, and I/O error handling

### DIFF
--- a/Tome/Sources/Tome/Storage/TranscriptLogger.swift
+++ b/Tome/Sources/Tome/Storage/TranscriptLogger.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+enum TranscriptLoggerError: LocalizedError {
+    case cannotCreateFile(String)
+    var errorDescription: String? {
+        switch self { case .cannotCreateFile(let p): return "Cannot create transcript at \(p)" }
+    }
+}
+
 /// Writes structured markdown transcripts to the vault.
 actor TranscriptLogger {
     private var fileHandle: FileHandle?
@@ -20,7 +27,7 @@ actor TranscriptLogger {
     private var lastSpeakersDetected: Set<String> = []
     private var lastSessionContext: String = ""
 
-    func startSession(sourceApp: String, vaultPath: String, sessionType: SessionType = .callCapture) {
+    func startSession(sourceApp: String, vaultPath: String, sessionType: SessionType = .callCapture) throws {
         self.sourceApp = sourceApp
         self.sessionStartTime = Date()
         self.speakersDetected = []
@@ -31,7 +38,7 @@ actor TranscriptLogger {
 
         let expandedPath = NSString(string: vaultPath).expandingTildeInPath
         let directory = URL(fileURLWithPath: expandedPath)
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
         let now = sessionStartTime!
         let fileFmt = DateFormatter()
@@ -87,8 +94,9 @@ tags:
 
 """
 
-        FileManager.default.createFile(atPath: currentFilePath!.path, contents: content.data(using: .utf8))
-        fileHandle = try? FileHandle(forWritingTo: currentFilePath!)
+        let created = FileManager.default.createFile(atPath: currentFilePath!.path, contents: content.data(using: .utf8))
+        guard created else { throw TranscriptLoggerError.cannotCreateFile(currentFilePath!.path) }
+        fileHandle = try FileHandle(forWritingTo: currentFilePath!)
         fileHandle?.seekToEndOfFile()
     }
 
@@ -189,9 +197,10 @@ tags:
 
     /// Call AFTER diarization is complete. Rewrites frontmatter with correct
     /// duration, speaker count, attendees, and optionally renames the file.
-    func finalizeFrontmatter() async {
+    @discardableResult
+    func finalizeFrontmatter() async -> URL? {
         guard let filePath = lastSessionFilePath,
-              let startTime = lastSessionStartTime else { return }
+              let startTime = lastSessionStartTime else { return nil }
 
         await Self.rewriteFrontmatter(
             filePath: filePath,
@@ -214,9 +223,11 @@ tags:
             lastSessionFilePath = newPath
         }
 
+        let savedPath = lastSessionFilePath
         lastSessionStartTime = nil
         lastSpeakersDetected = []
         lastSessionContext = ""
+        return savedPath
     }
 
     private static func rewriteFrontmatter(

--- a/Tome/Sources/Tome/Transcription/StreamingTranscriber.swift
+++ b/Tome/Sources/Tome/Transcription/StreamingTranscriber.swift
@@ -44,14 +44,17 @@ final class StreamingTranscriber: @unchecked Sendable {
     private static let flushInterval = 480_000
 
     /// Main loop: reads audio buffers, runs VAD, transcribes speech segments.
-    func run(stream: AsyncStream<AVAudioPCMBuffer>) async {
+    /// Returns `true` if the loop exited due to fatal (repeated) errors.
+    @discardableResult
+    func run(stream: AsyncStream<AVAudioPCMBuffer>) async -> Bool {
         var vadState = await vadManager.makeStreamState()
         var speechSamples: [Float] = []
         var vadBuffer: [Float] = []
         var isSpeaking = false
         var bufferCount = 0
+        var consecutiveErrors = 0
 
-        for await buffer in stream {
+        outerLoop: for await buffer in stream {
             bufferCount += 1
             if bufferCount <= 3 {
                 let fmt = buffer.format
@@ -80,6 +83,7 @@ final class StreamingTranscriber: @unchecked Sendable {
                         timeResolution: 2
                     )
                     vadState = result.state
+                    consecutiveErrors = 0
 
                     if let event = result.event {
                         switch event.kind {
@@ -94,7 +98,12 @@ final class StreamingTranscriber: @unchecked Sendable {
                             if speechSamples.count > 8000 {
                                 let segment = speechSamples
                                 speechSamples.removeAll(keepingCapacity: true)
-                                await transcribeSegment(segment)
+                                if await !transcribeSegment(segment) {
+                                    consecutiveErrors += 1
+                                    if consecutiveErrors > 10 { break outerLoop }
+                                } else {
+                                    consecutiveErrors = 0
+                                }
                             } else {
                                 speechSamples.removeAll(keepingCapacity: true)
                             }
@@ -108,11 +117,18 @@ final class StreamingTranscriber: @unchecked Sendable {
                         if speechSamples.count >= Self.flushInterval {
                             let segment = speechSamples
                             speechSamples.removeAll(keepingCapacity: true)
-                            await transcribeSegment(segment)
+                            if await !transcribeSegment(segment) {
+                                consecutiveErrors += 1
+                                if consecutiveErrors > 10 { break outerLoop }
+                            } else {
+                                consecutiveErrors = 0
+                            }
                         }
                     }
                 } catch {
                     log.error("VAD error: \(error.localizedDescription)")
+                    consecutiveErrors += 1
+                    if consecutiveErrors > 10 { break outerLoop }
                 }
             }
         }
@@ -120,17 +136,22 @@ final class StreamingTranscriber: @unchecked Sendable {
         if speechSamples.count > 8000 {
             await transcribeSegment(speechSamples)
         }
+
+        return consecutiveErrors > 10
     }
 
-    private func transcribeSegment(_ samples: [Float]) async {
+    /// Returns `true` on success, `false` on ASR error.
+    private func transcribeSegment(_ samples: [Float]) async -> Bool {
         do {
             let result = try await asrManager.transcribe(samples, source: audioSource)
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !text.isEmpty else { return }
+            guard !text.isEmpty else { return true }
             log.info("[\(self.speaker.rawValue)] transcribed: \(text.prefix(80))")
             onFinal(text)
+            return true
         } catch {
             log.error("ASR error: \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
+++ b/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
@@ -25,7 +25,7 @@ func diagLog(_ msg: String) {
 final class TranscriptionEngine {
     private(set) var isRunning = false
     private(set) var assetStatus: String = "Ready"
-    private(set) var lastError: String?
+    var lastError: String?
 
     private let systemCapture = SystemAudioCapture()
     private let micCapture = MicCapture()
@@ -130,8 +130,11 @@ final class TranscriptionEngine {
                 }
             }
         )
-        micTask = Task.detached {
-            await micTranscriber.run(stream: micStream)
+        micTask = Task.detached { [weak self] in
+            let hadFatalError = await micTranscriber.run(stream: micStream)
+            if hadFatalError {
+                await MainActor.run { self?.lastError = "Mic transcription failed — restart session" }
+            }
         }
 
         // 5. Start system audio transcription
@@ -151,8 +154,11 @@ final class TranscriptionEngine {
                     }
                 }
             )
-            sysTask = Task.detached {
-                await sysTranscriber.run(stream: sysStream)
+            sysTask = Task.detached { [weak self] in
+                let hadFatalError = await sysTranscriber.run(stream: sysStream)
+                if hadFatalError {
+                    await MainActor.run { self?.lastError = "System audio transcription failed — restart session" }
+                }
             }
         }
 
@@ -205,8 +211,11 @@ final class TranscriptionEngine {
                 }
             }
         )
-        micTask = Task.detached {
-            await micTranscriber.run(stream: micStream)
+        micTask = Task.detached { [weak self] in
+            let hadFatalError = await micTranscriber.run(stream: micStream)
+            if hadFatalError {
+                await MainActor.run { self?.lastError = "Mic transcription failed — restart session" }
+            }
         }
 
         diagLog("[ENGINE-MIC-SWAP] mic restarted on device \(targetMicID)")
@@ -280,6 +289,7 @@ final class TranscriptionEngine {
     }
 
     func stop() async {
+        lastError = nil
         removeDefaultDeviceListener()
         micTask?.cancel()
         sysTask?.cancel()

--- a/Tome/Sources/Tome/Views/ContentView.swift
+++ b/Tome/Sources/Tome/Views/ContentView.swift
@@ -28,6 +28,8 @@ struct ContentView: View {
     @State private var activeSessionType: SessionType?
     @State private var detectedAppName: String?
     @State private var silenceSeconds: Int = 0
+    @State private var savedFileURL: URL?
+    @State private var bannerDismissTask: Task<Void, Never>?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -44,6 +46,26 @@ struct ContentView: View {
             )
 
             Divider()
+
+            if let url = savedFileURL, activeSessionType == nil {
+                HStack {
+                    Text("Saved to \(url.lastPathComponent)")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Color.fg2)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                    Button("Show in Finder") {
+                        NSWorkspace.shared.selectFile(url.path, inFileSystemAtPath: url.deletingLastPathComponent().path)
+                        savedFileURL = nil
+                    }
+                    .font(.system(size: 11))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accent1)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 6)
+            }
 
             // Bottom bar: capture buttons + controls
             ControlBar(
@@ -161,12 +183,14 @@ struct ContentView: View {
     private func startSession(type: SessionType) {
         transcriptStore.clear()
         silenceSeconds = 0
-        activeSessionType = type
+        savedFileURL = nil
+        bannerDismissTask?.cancel()
 
         // Determine output folder and app bundle ID based on session type
         let outputPath: String
         let sourceApp: String
         var appBundleID: String?
+        var resolvedAppName: String?
 
         switch type {
         case .callCapture:
@@ -177,24 +201,31 @@ struct ContentView: View {
                let appName = conferencingBundleIDs[bundleID] {
                 sourceApp = appName
                 appBundleID = bundleID
-                detectedAppName = appName
+                resolvedAppName = appName
             } else {
                 sourceApp = "Call"
-                detectedAppName = nil
             }
         case .voiceMemo:
             outputPath = settings.vaultVoicePath
             sourceApp = "Voice Memo"
-            detectedAppName = nil
         }
 
         Task {
+            transcriptionEngine?.lastError = nil
             await sessionStore.startSession()
-            await transcriptLogger.startSession(
-                sourceApp: sourceApp,
-                vaultPath: outputPath,
-                sessionType: type
-            )
+            do {
+                try await transcriptLogger.startSession(
+                    sourceApp: sourceApp,
+                    vaultPath: outputPath,
+                    sessionType: type
+                )
+            } catch {
+                await sessionStore.endSession()
+                transcriptionEngine?.lastError = error.localizedDescription
+                return
+            }
+            activeSessionType = type
+            detectedAppName = resolvedAppName
             if type == .callCapture {
                 await transcriptionEngine?.start(
                     locale: settings.locale,
@@ -230,7 +261,17 @@ struct ContentView: View {
             }
 
             // Finalize frontmatter AFTER diarization (duration, speakers, rename)
-            await transcriptLogger.finalizeFrontmatter()
+            let savedPath = await transcriptLogger.finalizeFrontmatter()
+
+            // Only show banner if not already in a new session
+            if activeSessionType == nil, let savedPath {
+                savedFileURL = savedPath
+                bannerDismissTask?.cancel()
+                bannerDismissTask = Task {
+                    try? await Task.sleep(for: .seconds(8))
+                    if !Task.isCancelled { savedFileURL = nil }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Surface fatal transcription errors** — if VAD/ASR fails 10+ times consecutively, the error is shown in the UI via the existing ControlBar error display
- **"Saved to..." banner** — after stopping a session, shows the filename with a "Show in Finder" button; auto-dismisses after 8 seconds
- **File I/O error handling** — `TranscriptLogger.startSession()` now throws on file creation failure instead of silently losing the transcript. UI stays in non-recording state and shows the error
- **lastError lifecycle fix** — cleared on `stop()` and before new session start, so stale errors from a previous session don't persist

## Files changed

- `StreamingTranscriber.swift` — `run()` returns `Bool` for fatal error, local consecutive error counter with labeled break
- `TranscriptionEngine.swift` — `lastError` writable externally, cleared in `stop()`, detached tasks check `run()` return value
- `TranscriptLogger.swift` — `startSession()` throws, `finalizeFrontmatter()` returns saved `URL?`, new error enum
- `ContentView.swift` — save banner UI, `activeSessionType` set after validation, logger errors caught and surfaced

## Test plan

- [ ] Build the project — confirm no compile errors
- [ ] Set vault path to a non-existent/unwritable directory → start session → should see error, UI should NOT show "Recording"
- [ ] Set vault path correctly → start → stop → should see "Saved to..." banner with correct filename
- [ ] Click "Show in Finder" → opens the file location
- [ ] Banner auto-dismisses after 8 seconds
- [ ] Start a new session → banner clears immediately