### PR TITLE
Upgrade to Parakeet-TDT v3 for multilingual transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-Tome is a macOS app that captures meetings and voice memos, transcribes them locally with Parakeet-TDT v2, and drops structured `.md` files straight into your Obsidian vault. Everything runs on-device. Nothing phones home.
+Tome is a macOS app that captures meetings and voice memos, transcribes them locally with Parakeet-TDT v3, and drops structured `.md` files straight into your Obsidian vault. Everything runs on-device. Nothing phones home.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/Gremble-io/Tome/main/assets/screenshot-idle.png" width="350" alt="Tome — idle state" />
@@ -39,7 +39,7 @@ I'm putting it out there because if you're running Obsidian with any kind of AI 
 
 - **Plain markdown out.** YAML frontmatter, tags, timestamps. Your vault already knows what to do with it. No proprietary export, no copy-paste, no middleman.
 - **Built for the agent pipeline.** Tome is just the capture layer. You talk, it transcribes, your agent picks up the `.md` and does whatever you've wired it to do.
-- **Runs on your machine.** Parakeet-TDT v2 on Apple Silicon. No API keys, no accounts, no subscriptions, no data leaving the building.
+- **Runs on your machine.** Parakeet-TDT v3 on Apple Silicon. No API keys, no accounts, no subscriptions, no data leaving the building.
 
 ```
 speak → capture → vault → agent → knowledge base
@@ -49,7 +49,7 @@ Tome does the first three. Your agent does the rest.
 
 ## Features
 
-- **Local transcription** via Parakeet-TDT v2 ([FluidAudio](https://github.com/FluidInference/FluidAudio)) on Apple Silicon. Nothing hits the network.
+- **Multilingual transcription** via Parakeet-TDT v3 ([FluidAudio](https://github.com/FluidInference/FluidAudio)) on Apple Silicon. 25 European languages, auto-detected. Nothing hits the network.
 - **Call Capture** grabs mic + system audio. Detects which conferencing app you're in (Teams, Zoom, Slack, etc.) and filters audio to just that app. Your Spotify and notification sounds stay out of the transcript.
 - **Voice Memo** is mic only. For quick thoughts, verbal notes, stream of consciousness. Saves to a separate folder so it doesn't clutter your meeting transcripts.
 - **Speaker diarization** runs after the call ends. pyannote splits the remote audio into Speaker 2, Speaker 3, Speaker 4. Not perfect, but way better than one wall of unattributed text.
@@ -65,7 +65,7 @@ Tome does the first three. Your agent does the rest.
 └─────────────┘     │  Tome            │     │  Obsidian     │
                     │  ┌────────────┐  │────▶│  Vault        │
 ┌─────────────┐     │  │ Parakeet   │  │     │  (.md files)  │
-│  System      │────▶│  │ TDT v2    │  │     │               │
+│  System      │────▶│  │ TDT v3    │  │     │               │
 │  Audio       │     │  └────────────┘  │     └───────┬───────┘
 └─────────────┘     └──────────────────┘             │
                                                      ▼

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,14 @@
 # Roadmap
 
+## Shipped
+
+**Multilingual transcription (v1.1.0)**
+Upgraded from Parakeet-TDT v2 (English-only) to v3 (25 European languages). Auto-detects spoken language.
+
 ## Up next
 
 **Custom vocabulary boosting**
-Decode-time vocabulary biasing via CTC keyword spotting. Feed a JSON file of domain-specific terms and the transcriber prioritizes those words. No retraining needed.
+Decode-time vocabulary biasing via CTC keyword spotting. Feed a text file of domain-specific terms and the transcriber prioritizes those words. No retraining needed.
 
 **FluidAudio fork**
 Upstream fixes to the ASR pipeline: source-specific decoder state reset and a thread safety improvement.

--- a/Tome/Package.swift
+++ b/Tome/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Tome",
     platforms: [.macOS(.v26)],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.7.9"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.1"..<"0.12.2"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
     ],
     targets: [

--- a/Tome/Sources/Tome/Info.plist
+++ b/Tome/Sources/Tome/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>io.gremble.tome</string>
     <key>CFBundleVersion</key>
-    <string>1.0.1</string>
+    <string>1.1.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.1</string>
+    <string>1.1.0</string>
     <key>CFBundleExecutable</key>
     <string>Tome</string>
     <key>CFBundleIconFile</key>

--- a/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
+++ b/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
@@ -66,10 +66,10 @@ final class TranscriptionEngine {
         isRunning = true
 
         // 1. Load FluidAudio models
-        assetStatus = "Loading ASR model (~600MB first run)..."
+        assetStatus = "Downloading multilingual model (first run)..."
         diagLog("[ENGINE-1] loading FluidAudio ASR models...")
         do {
-            let models = try await AsrModels.downloadAndLoad(version: .v2)
+            let models = try await AsrModels.downloadAndLoad(version: .v3)
             assetStatus = "Initializing ASR..."
             let asr = AsrManager(config: .default)
             try await asr.initialize(models: models)
@@ -168,7 +168,7 @@ final class TranscriptionEngine {
             }
         }
 
-        assetStatus = "Transcribing (Parakeet-TDT v2)"
+        assetStatus = "Transcribing (Parakeet-TDT v3)"
         diagLog("[ENGINE-6] all transcription tasks started")
 
         // Install CoreAudio listener for default input device changes

--- a/Tome/Sources/Tome/Views/SettingsView.swift
+++ b/Tome/Sources/Tome/Views/SettingsView.swift
@@ -61,11 +61,6 @@ struct SettingsView: View {
                 .font(.system(size: 12))
             }
 
-            Section("Transcription") {
-                TextField("Locale (e.g. en-US)", text: $settings.transcriptionLocale)
-                    .font(.system(size: 12, design: .monospaced))
-            }
-
             Section("Privacy") {
                 Toggle("Hide from screen sharing", isOn: $settings.hideFromScreenShare)
                     .font(.system(size: 12))


### PR DESCRIPTION
Switch from v2 (English-only) to v3 (25 European languages with auto-detection). Pin FluidAudio to 0.12.1 to avoid the breaking AsrManager actor change in 0.12.6+. Remove the unused locale TextField from Settings since v3 auto-detects language.

