### PR TITLE
Address issues #5 and #6: Gatekeeper workaround, build hardening, roadmap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ Tome/Sources/Tome/
 - **Diarization is imperfect.** Works well with headset mics. Laptop speakers with crosstalk will give you worse speaker separation.
 - **No live speaker labels.** Diarization runs after the session ends. During the call, remote audio shows as a single stream.
 
+## Troubleshooting
+
+**"Tome is damaged and can't be opened"**
+
+This is macOS Gatekeeper blocking an unsigned app. Until a signed release is available:
+
+1. Right-click (or Control-click) `Tome.app` in `/Applications`
+2. Click **Open**
+3. In the dialog, click **Open** again
+
+You only need to do this once — after that, Tome launches normally.
+
+Alternatively, build from source (see [Build](#build) above) to avoid Gatekeeper entirely.
+
 ## Credits
 
 Started from [OpenGranola](https://github.com/yazinsai/OpenGranola). Substantially rewritten from there.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,11 @@ Upgraded from Parakeet-TDT v2 (English-only) to v3 (25 European languages). Auto
 **Custom vocabulary boosting**
 Decode-time vocabulary biasing via CTC keyword spotting. Feed a text file of domain-specific terms and the transcriber prioritizes those words. No retraining needed.
 
-**FluidAudio fork**
-Upstream fixes to the ASR pipeline: source-specific decoder state reset and a thread safety improvement.
+**FluidAudio fork** *(in progress)*
+Fork FluidAudio with `@unchecked Sendable` on `AsrManager`/`VadManager` to fix Swift 6 build failures on Xcode 26.4+. Also includes source-specific decoder state reset.
+
+**Per-stream model instances**
+Create separate `AsrManager`/`VadManager` per audio stream to eliminate shared state across concurrent tasks.
 
 **JSONL crash recovery**
 Rebuild transcripts from session data if the app exits mid-session.

--- a/scripts/build_swift_app.sh
+++ b/scripts/build_swift_app.sh
@@ -128,7 +128,9 @@ if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
   echo "Code signing complete"
   codesign -vvv "$APP_DIR"
 else
-  echo "Warning: No signing identity found. App will be unsigned."
+  echo "Error: No signing identity found. App will be unsigned."
+  echo "Set CODESIGN_IDENTITY or install a Developer ID certificate."
+  exit 1
 fi
 
 # Install to /Applications

--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -73,7 +73,7 @@ fi
 
 if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
   echo "Signing DMG with: $CODESIGN_IDENTITY"
-  codesign --force --sign "$CODESIGN_IDENTITY" "$DMG_PATH"
+  codesign --force --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "$DMG_PATH"
 fi
 
 echo "DMG created: $DMG_PATH"


### PR DESCRIPTION
- Add Troubleshooting section to README with Gatekeeper workaround (#6)
- Fail build on missing signing identity instead of warning (#6)
- Add --options runtime --timestamp to DMG codesign (#6)
- Update ROADMAP with FluidAudio fork status and per-stream instances (#5)

https://claude.ai/code/session_01D4ADJYvjRs9AkvKb2LJUtT