### PR TITLE
Upgrade FluidAudio for Swift 6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.1] — 2026-03-30
+- Upgraded FluidAudio to latest (actor-based AsrManager) — fixes Swift 6 build failures on Xcode 26.4+
+- Build script now fails on missing code signing identity instead of silently shipping unsigned
+- Added Gatekeeper troubleshooting to README
+
 ## [1.1.0] — 2026-03-29
 - Multilingual transcription: Parakeet-TDT v3, 25 European languages with auto-detection
 - Pinned FluidAudio to 0.12.1

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Tome/Sources/Tome/
     ├── ContentView.swift
     ├── ControlBar.swift
     ├── TranscriptView.swift
+    ├── WaveformView.swift
     ├── SettingsView.swift
     ├── OnboardingView.swift
     └── CheckForUpdatesView.swift

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,13 +5,13 @@
 **Multilingual transcription (v1.1.0)**
 Upgraded from Parakeet-TDT v2 (English-only) to v3 (25 European languages). Auto-detects spoken language.
 
+**FluidAudio upgrade (v1.1.1)**
+Upgraded to latest FluidAudio with actor-based `AsrManager`. Fixes Swift 6 build failures on Xcode 26.4+.
+
 ## Up next
 
 **Custom vocabulary boosting**
 Decode-time vocabulary biasing via CTC keyword spotting. Feed a text file of domain-specific terms and the transcriber prioritizes those words. No retraining needed.
-
-**FluidAudio fork** *(in progress)*
-Fork FluidAudio with `@unchecked Sendable` on `AsrManager`/`VadManager` to fix Swift 6 build failures on Xcode 26.4+. Also includes source-specific decoder state reset.
 
 **Per-stream model instances**
 Create separate `AsrManager`/`VadManager` per audio stream to eliminate shared state across concurrent tasks.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security
+
+Report security issues to jason@gremble.io.

--- a/Tome/Package.swift
+++ b/Tome/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Tome",
     platforms: [.macOS(.v26)],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.1"..<"0.12.2"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", revision: "ea500621819cadc46d6212af44624f2b45ab3240"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
     ],
     targets: [

--- a/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
+++ b/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
@@ -72,7 +72,7 @@ final class TranscriptionEngine {
             let models = try await AsrModels.downloadAndLoad(version: .v3)
             assetStatus = "Initializing ASR..."
             let asr = AsrManager(config: .default)
-            try await asr.initialize(models: models)
+            try await asr.loadModels(models)
             self.asrManager = asr
 
             assetStatus = "Loading VAD model..."


### PR DESCRIPTION
Fixes #5.

- Pin FluidAudio to latest main (actor-based AsrManager resolves Swift 6 sendability errors)
- Update `initialize(models:)` → `loadModels(_:)` for new API
- Add v1.1.1 changelog entry
- Add SECURITY.md
- Add WaveformView to README architecture diagram
- Move FluidAudio upgrade to Shipped in ROADMAP