### PR TITLE
Fix mic device switch between sessions

### DIFF
--- a/Tome/Sources/Tome/Audio/MicCapture.swift
+++ b/Tome/Sources/Tome/Audio/MicCapture.swift
@@ -33,6 +33,13 @@ final class MicCapture: @unchecked Sendable {
                     UInt32(MemoryLayout<AudioDeviceID>.size)
                 )
                 diagLog("[MIC-2] setInputDevice status=\(status) (0=ok)")
+                guard status == noErr else {
+                    let msg = "Failed to set input device (OSStatus \(status))"
+                    diagLog("[MIC-2-FAIL] \(msg)")
+                    errorHolder.value = msg
+                    continuation.finish()
+                    return
+                }
             } else {
                 diagLog("[MIC-2] no deviceID, using system default")
             }
@@ -95,6 +102,7 @@ final class MicCapture: @unchecked Sendable {
     func stop() {
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
+        engine.reset()
         _audioLevel.value = 0
     }
 


### PR DESCRIPTION
## Summary
- Adds `engine.reset()` after `engine.stop()` in `MicCapture.stop()` to force AVAudioEngine to discard its cached inputNode, so the next session picks up the new device's format correctly
- Adds a guard on `AudioUnitSetProperty` return value to fail fast instead of silently proceeding with a stale device binding

Closes #12

## Test plan
- [x] Build succeeds with no new warnings
- [x] Tested live: switched MacBook mic → AirPods → MacBook mic mid-session, audio captured correctly on each swap
- [x] Verified via diagnostic logs that engine restarts cleanly with correct format on each device switch