### PR TITLE
Fix button tap crash (SIGSEGV in MainActor.assumeIsolated)

### DIFF
--- a/Tome/Sources/Tome/Views/ContentView.swift
+++ b/Tome/Sources/Tome/Views/ContentView.swift
@@ -103,7 +103,8 @@ struct ContentView: View {
                     continue
                 }
                 if engine.isRunning {
-                    audioLevel = engine.audioLevel
+                    let newLevel = engine.audioLevel
+                    if abs(newLevel - audioLevel) > 0.005 { audioLevel = newLevel }
                     if audioLevel > 0.01 {
                         silenceSeconds = 0
                     }


### PR DESCRIPTION
## Summary
- Adds a dead-zone threshold (`0.005`) to the audio level polling loop so `@State audioLevel` is only written when the value meaningfully changes
- Prevents the 10Hz flood of redundant SwiftUI view invalidations that corrupted the AttributeGraph, causing SIGSEGV on any button tap

Closes #10

## Test plan
- [x] Build succeeds with no new warnings
- [x] Tested live: started/stopped recordings, opened settings, tapped all buttons — no crashes
- [x] Waveform visualizer still responds to audio input
- [x] Verified via diagnostic logs that transcription pipeline runs normally