### PR TITLE
Raise VAD threshold on system audio to reduce speaker misattribution

### DIFF
--- a/Tome/Sources/Tome/Transcription/StreamingTranscriber.swift
+++ b/Tome/Sources/Tome/Transcription/StreamingTranscriber.swift
@@ -8,6 +8,7 @@ final class StreamingTranscriber: @unchecked Sendable {
     private let vadManager: VadManager
     private let speaker: Speaker
     private let audioSource: AudioSource
+    private let vadConfig: VadConfig
     private let onPartial: @Sendable (String) -> Void
     private let onFinal: @Sendable (String) -> Void
     private let log = Logger(subsystem: "io.gremble.tome", category: "StreamingTranscriber")
@@ -26,6 +27,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         vadManager: VadManager,
         speaker: Speaker,
         audioSource: AudioSource = .microphone,
+        vadConfig: VadConfig = .default,
         onPartial: @escaping @Sendable (String) -> Void,
         onFinal: @escaping @Sendable (String) -> Void
     ) {
@@ -33,6 +35,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         self.vadManager = vadManager
         self.speaker = speaker
         self.audioSource = audioSource
+        self.vadConfig = vadConfig
         self.onPartial = onPartial
         self.onFinal = onFinal
     }
@@ -78,7 +81,7 @@ final class StreamingTranscriber: @unchecked Sendable {
                     let result = try await vadManager.processStreamingChunk(
                         chunk,
                         state: vadState,
-                        config: .default,
+                        config: vadConfig,
                         returnSeconds: true,
                         timeResolution: 2
                     )

--- a/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
+++ b/Tome/Sources/Tome/Transcription/TranscriptionEngine.swift
@@ -147,6 +147,7 @@ final class TranscriptionEngine {
                 vadManager: vadManager,
                 speaker: .them,
                 audioSource: .system,
+                vadConfig: VadConfig(defaultThreshold: 0.92),
                 onPartial: { text in
                     Task { @MainActor in store.volatileThemText = text }
                 },


### PR DESCRIPTION
## Summary

- Adds per-stream `VadConfig` support to `StreamingTranscriber` so mic and system audio can use different speech probability thresholds
- Raises system audio VAD threshold from 0.85 (default) to 0.92 to reject low-confidence echo bleed from conferencing apps
- Mic stream unchanged — uses default 0.85 threshold

## Context

Fixes #19. ScreenCaptureKit captures a conferencing app's full audio output, which includes a processed echo of the local user's mic. This echo triggers Silero VAD on the system audio stream and gets misattributed as "Them." The echo produces lower speech probability scores than genuine remote speech — raising the threshold filters it without affecting real speakers.

## Changes

| File | Change |
|------|--------|
| `StreamingTranscriber.swift` | Add `vadConfig: VadConfig = .default` param, use in `processStreamingChunk` |
| `TranscriptionEngine.swift` | Pass `VadConfig(defaultThreshold: 0.92)` to system audio transcriber |

## Test plan

- [ ] Build compiles with no errors
- [ ] Mic transcription works identically (unchanged threshold)
- [ ] Run a call with AirPods output + laptop mic — verify echo bleed utterances are reduced
- [ ] Verify genuine remote speech still transcribes correctly
- [ ] Check `/tmp/tome.log` for VAD speech events on system stream
- [ ] If 0.92 is too aggressive for quiet speakers, adjust down to 0.90

https://claude.ai/code/session_01N7M4e28AH8GiSWCFkS2xYP