### PR TITLE
Add post-session speaker naming UI

### DIFF
--- a/Tome/Sources/Tome/Storage/TranscriptLogger.swift
+++ b/Tome/Sources/Tome/Storage/TranscriptLogger.swift
@@ -299,9 +299,11 @@ tags:
 
     /// Rewrite the transcript file, replacing "Them" labels with diarized speaker IDs.
     /// Segments are (speakerId, startTimeSeconds, endTimeSeconds) from the offline diarizer.
-    func rewriteWithDiarization(segments: [(speakerId: String, startTime: Float, endTime: Float)]) {
-        guard let filePath = currentFilePath ?? lastSessionFilePath else { return }
-        guard var content = try? String(contentsOf: filePath, encoding: .utf8) else { return }
+    /// Returns the speaker map (raw diarization ID → friendly label like "Speaker 2").
+    @discardableResult
+    func rewriteWithDiarization(segments: [(speakerId: String, startTime: Float, endTime: Float)]) -> [String: String] {
+        guard let filePath = currentFilePath ?? lastSessionFilePath else { return [:] }
+        guard var content = try? String(contentsOf: filePath, encoding: .utf8) else { return [:] }
 
         // Build a map of unique diarization speaker IDs → friendly labels (Speaker 2, 3, etc.)
         var diarSpeakerMap: [String: String] = [:]
@@ -319,7 +321,7 @@ tags:
 
         // For each "**Them** (HH:mm:ss)" line, find the best matching diarization segment
         let pattern = #"\*\*Them\*\* \((\d{2}:\d{2}:\d{2})\)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return diarSpeakerMap }
 
         let nsContent = content as NSString
         let matches = regex.matches(in: content, range: NSRange(location: 0, length: nsContent.length))
@@ -379,6 +381,31 @@ tags:
 
         // Atomic write
         let tmpPath = filePath.deletingLastPathComponent().appendingPathComponent(".tome_diar_tmp.md")
+        try? content.write(to: tmpPath, atomically: true, encoding: .utf8)
+        try? FileManager.default.removeItem(at: filePath)
+        try? FileManager.default.moveItem(at: tmpPath, to: filePath)
+
+        return diarSpeakerMap
+    }
+
+    /// Replace generic speaker labels (e.g. "Speaker 2") with real names in the transcript.
+    /// mapping: ["Speaker 2": "Alice", "Speaker 3": "Bob"]
+    func applySpeakerRenames(_ mapping: [String: String]) {
+        guard !mapping.isEmpty else { return }
+        guard let filePath = lastSessionFilePath else { return }
+        guard var content = try? String(contentsOf: filePath, encoding: .utf8) else { return }
+
+        for (generic, realName) in mapping {
+            content = content.replacingOccurrences(of: "**\(generic)**", with: "**\(realName)**")
+        }
+
+        // Update speaker tracking so finalizeFrontmatter writes correct attendees
+        for (generic, realName) in mapping {
+            lastSpeakersDetected.remove(generic)
+            lastSpeakersDetected.insert(realName)
+        }
+
+        let tmpPath = filePath.deletingLastPathComponent().appendingPathComponent(".tome_rename_tmp.md")
         try? content.write(to: tmpPath, atomically: true, encoding: .utf8)
         try? FileManager.default.removeItem(at: filePath)
         try? FileManager.default.moveItem(at: tmpPath, to: filePath)

--- a/Tome/Sources/Tome/Views/ContentView.swift
+++ b/Tome/Sources/Tome/Views/ContentView.swift
@@ -31,6 +31,9 @@ struct ContentView: View {
     @State private var savedFileURL: URL?
     @State private var bannerDismissTask: Task<Void, Never>?
     @State private var sessionElapsed: Int = 0
+    @State private var showSpeakerNaming = false
+    @State private var speakerLabelsForNaming: [String] = []
+    @State private var speakerNamingContinuation: CheckedContinuation<[String: String], Never>?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -79,6 +82,24 @@ struct ContentView: View {
             if showOnboarding {
                 OnboardingView(isPresented: $showOnboarding)
                     .transition(.opacity)
+            }
+        }
+        .overlay {
+            if showSpeakerNaming {
+                SpeakerNamingView(
+                    speakerLabels: speakerLabelsForNaming,
+                    onApply: { mapping in
+                        showSpeakerNaming = false
+                        speakerNamingContinuation?.resume(returning: mapping)
+                        speakerNamingContinuation = nil
+                    },
+                    onSkip: {
+                        showSpeakerNaming = false
+                        speakerNamingContinuation?.resume(returning: [:])
+                        speakerNamingContinuation = nil
+                    }
+                )
+                .transition(.opacity)
             }
         }
         .onChange(of: showOnboarding) {
@@ -328,7 +349,25 @@ struct ContentView: View {
                 transcriptionEngine?.assetStatus = "Identifying speakers..."
                 if let segments = await transcriptionEngine?.runPostSessionDiarization() {
                     transcriptionEngine?.assetStatus = "Rewriting transcript..."
-                    await transcriptLogger.rewriteWithDiarization(segments: segments)
+                    let speakerMap = await transcriptLogger.rewriteWithDiarization(segments: segments)
+
+                    let genericLabels = Set(speakerMap.values).sorted()
+                    if !genericLabels.isEmpty {
+                        transcriptionEngine?.assetStatus = "Ready"
+
+                        let mapping: [String: String] = await withCheckedContinuation { continuation in
+                            speakerLabelsForNaming = genericLabels
+                            speakerNamingContinuation = continuation
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                showSpeakerNaming = true
+                            }
+                        }
+
+                        if !mapping.isEmpty {
+                            transcriptionEngine?.assetStatus = "Applying names..."
+                            await transcriptLogger.applySpeakerRenames(mapping)
+                        }
+                    }
                 }
             }
 

--- a/Tome/Sources/Tome/Views/SpeakerNamingView.swift
+++ b/Tome/Sources/Tome/Views/SpeakerNamingView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+struct SpeakerNamingView: View {
+    /// Generic labels discovered by diarization, e.g. ["Speaker 2", "Speaker 3"]
+    let speakerLabels: [String]
+    /// Called with mapping from generic label -> user-entered name (empty values filtered out)
+    let onApply: ([String: String]) -> Void
+    /// Called when user wants to skip naming
+    let onSkip: () -> Void
+
+    @State private var names: [String: String] = [:]
+    @FocusState private var focusedField: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // Header
+            VStack(spacing: 6) {
+                Image(systemName: "person.2.fill")
+                    .font(.system(size: 28, weight: .light))
+                    .foregroundStyle(Color.accent1)
+
+                Text("Name Speakers")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color.fg1)
+
+                Text("Assign names to the speakers\nidentified in this call.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(3)
+            }
+            .padding(.bottom, 20)
+
+            // Speaker fields
+            VStack(spacing: 8) {
+                // "You" row — non-editable, shown for context
+                HStack(spacing: 10) {
+                    Circle()
+                        .fill(Color.accent1.opacity(0.2))
+                        .frame(width: 28, height: 28)
+                        .overlay(
+                            Text("Y")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(Color.accent1)
+                        )
+
+                    Text("You")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(Color.fg2)
+
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+
+                // Editable speaker rows
+                ForEach(speakerLabels, id: \.self) { label in
+                    HStack(spacing: 10) {
+                        Circle()
+                            .fill(Color.fg2.opacity(0.2))
+                            .frame(width: 28, height: 28)
+                            .overlay(
+                                Text(speakerInitial(label))
+                                    .font(.system(size: 12, weight: .bold))
+                                    .foregroundStyle(Color.fg2)
+                            )
+
+                        TextField(label, text: binding(for: label))
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 12))
+                            .foregroundStyle(Color.fg1)
+                            .focused($focusedField, equals: label)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 6)
+                            .background(Color.bg1.opacity(0.7))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(focusedField == label ? Color.accent1.opacity(0.4) : Color.white.opacity(0.06))
+                            )
+                            .onSubmit { advanceFocus(from: label) }
+                    }
+                    .padding(.horizontal, 12)
+                }
+            }
+
+            Spacer()
+
+            // Buttons
+            HStack {
+                Button("Skip") { onSkip() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button {
+                    applyNames()
+                } label: {
+                    Text("Apply")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 8)
+                        .background(Color.accent1, in: RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.return, modifiers: [])
+            }
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.bg0)
+        .onAppear {
+            for label in speakerLabels {
+                names[label] = ""
+            }
+            focusedField = speakerLabels.first
+        }
+    }
+
+    private func binding(for label: String) -> Binding<String> {
+        Binding(
+            get: { names[label] ?? "" },
+            set: { names[label] = $0 }
+        )
+    }
+
+    private func speakerInitial(_ label: String) -> String {
+        // "Speaker 2" -> "2", "Speaker 3" -> "3"
+        String(label.last ?? "?")
+    }
+
+    private func applyNames() {
+        let mapping = names
+            .mapValues { $0.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "*", with: "") }
+            .filter { !$0.value.isEmpty }
+        onApply(mapping)
+    }
+
+    private func advanceFocus(from label: String) {
+        guard let index = speakerLabels.firstIndex(of: label) else { return }
+        let next = index + 1
+        if next < speakerLabels.count {
+            focusedField = speakerLabels[next]
+        } else {
+            applyNames()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- After diarization identifies distinct speakers in the "Them" stream, an inline overlay lets users assign real names (e.g. "Speaker 2" → "Alice") before the transcript is finalized
- Names are applied to both the markdown transcript body and the YAML frontmatter attendees list
- The step is skippable — users can keep generic labels by clicking Skip or leaving fields empty

## Changes

- **TranscriptLogger.swift** — `rewriteWithDiarization` now returns the speaker map; new `applySpeakerRenames(_:)` method replaces generic labels with user-provided names in the transcript file and updates the attendees tracking set
- **SpeakerNamingView.swift** (new) — Inline overlay with a text field per diarized speaker, matching the app's dark glass aesthetic. Tab/Return advances fields; `*` characters sanitized from input
- **ContentView.swift** — `stopSession()` uses `withCheckedContinuation` to pause after diarization rewrite, show the naming panel, and resume once the user applies or skips

## Test plan

- [ ] Start a Call Capture session with a conferencing app playing audio from 2+ people
- [ ] Stop the session — verify diarization runs, then naming panel appears
- [ ] Enter names for some/all speakers, click Apply — verify markdown has real names in body and frontmatter attendees
- [ ] Repeat and click Skip — verify generic "Speaker N" labels preserved
- [ ] Test with a single remote speaker — naming panel should still appear
- [ ] Test Voice Memo — naming panel should NOT appear (no diarization)
- [ ] Verify Tab/Return advances through fields, Return on last field triggers Apply