### PR TITLE
Add test suite for core logic (29 tests)

### DIFF
--- a/Tome/Package.resolved
+++ b/Tome/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "a3d5441852186709698c02923d4f349c1a5ac93e0c7266aa2b6aa8fca0bf5d48",
+  "originHash" : "7747d6a1da3f77417f8e2ce1a97d23d0a1266df2997ce79fe7638ff78394eb2c",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "1cf23303df75df13e8dc92a0343c40006fbbe234",
-        "version" : "0.12.1"
+        "revision" : "ea500621819cadc46d6212af44624f2b45ab3240"
       }
     },
     {
@@ -17,60 +16,6 @@
       "state" : {
         "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
         "version" : "2.9.0"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
-        "version" : "4.2.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
-        "version" : "2.3.2"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Tome/Package.swift
+++ b/Tome/Package.swift
@@ -19,5 +19,10 @@ let package = Package(
             path: "Sources/Tome",
             exclude: ["Info.plist", "Tome.entitlements", "Assets"]
         ),
+        .testTarget(
+            name: "TomeTests",
+            dependencies: ["Tome"],
+            path: "Tests/TomeTests"
+        ),
     ]
 )

--- a/Tome/Tests/TomeTests/ModelsTests.swift
+++ b/Tome/Tests/TomeTests/ModelsTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Tome
+
+final class ModelsTests: XCTestCase {
+
+    // MARK: - Speaker
+
+    func testSpeakerCodableYou() throws {
+        let data = try JSONEncoder().encode(Speaker.you)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "\"you\"")
+
+        let decoded = try JSONDecoder().decode(Speaker.self, from: data)
+        XCTAssertEqual(decoded, .you)
+    }
+
+    func testSpeakerCodableThem() throws {
+        let data = try JSONEncoder().encode(Speaker.them)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "\"them\"")
+
+        let decoded = try JSONDecoder().decode(Speaker.self, from: data)
+        XCTAssertEqual(decoded, .them)
+    }
+
+    func testSpeakerDecodeInvalidValue() {
+        let json = Data("\"unknown\"".utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(Speaker.self, from: json))
+    }
+
+    // MARK: - Utterance
+
+    func testUtteranceCodableRoundTrip() throws {
+        let date = Date(timeIntervalSince1970: 1_000_000)
+        let original = Utterance(text: "Hello world", speaker: .you, timestamp: date)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Utterance.self, from: data)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.text, original.text)
+        XCTAssertEqual(decoded.speaker, original.speaker)
+        XCTAssertEqual(
+            decoded.timestamp.timeIntervalSince1970,
+            original.timestamp.timeIntervalSince1970,
+            accuracy: 1
+        )
+    }
+
+    func testUtteranceDecodeIncompleteJSON() {
+        let json = Data("""
+        {"id":"12345678-1234-1234-1234-123456789012","speaker":"you","timestamp":"2024-01-01T00:00:00Z"}
+        """.utf8)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        XCTAssertThrowsError(try decoder.decode(Utterance.self, from: json))
+    }
+
+    func testUtteranceEmptyText() throws {
+        let utterance = Utterance(text: "", speaker: .them)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(utterance)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Utterance.self, from: data)
+        XCTAssertEqual(decoded.text, "")
+    }
+
+    // MARK: - SessionRecord
+
+    func testSessionRecordCodableISO8601() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = SessionRecord(speaker: .them, text: "Test text", timestamp: date)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SessionRecord.self, from: data)
+
+        XCTAssertEqual(decoded.speaker, original.speaker)
+        XCTAssertEqual(decoded.text, original.text)
+        XCTAssertEqual(
+            decoded.timestamp.timeIntervalSince1970,
+            original.timestamp.timeIntervalSince1970,
+            accuracy: 1
+        )
+    }
+}

--- a/Tome/Tests/TomeTests/SessionStoreTests.swift
+++ b/Tome/Tests/TomeTests/SessionStoreTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Tome
+
+final class SessionStoreTests: XCTestCase {
+    private var store: SessionStore!
+    private var filesBefore: Set<URL> = []
+
+    override func setUp() async throws {
+        store = SessionStore()
+        let dir = await store.sessionsDirectoryURL
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil
+        )) ?? []
+        filesBefore = Set(files)
+    }
+
+    override func tearDown() async throws {
+        await store.endSession()
+        let dir = await store.sessionsDirectoryURL
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil
+        )) ?? []
+        for file in Set(files).subtracting(filesBefore) {
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+
+    private func findNewFile() async throws -> URL {
+        let dir = await store.sessionsDirectoryURL
+        let files = try FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil
+        )
+        return try XCTUnwrap(Set(files).subtracting(filesBefore).first)
+    }
+
+    // MARK: - Happy Path
+
+    func testStartSessionCreatesFile() async throws {
+        await store.startSession()
+
+        let file = try await findNewFile()
+        XCTAssertEqual(file.pathExtension, "jsonl")
+        XCTAssertTrue(file.lastPathComponent.hasPrefix("session_"))
+    }
+
+    func testAppendRecordWritesJSONL() async throws {
+        await store.startSession()
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        await store.appendRecord(SessionRecord(speaker: .you, text: "Hello", timestamp: date))
+        await store.appendRecord(SessionRecord(speaker: .them, text: "Hi", timestamp: date))
+        await store.appendRecord(SessionRecord(speaker: .you, text: "Bye", timestamp: date))
+        await store.endSession()
+
+        let file = try await findNewFile()
+        let content = try String(contentsOf: file, encoding: .utf8)
+        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 3)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        for line in lines {
+            let record = try decoder.decode(SessionRecord.self, from: Data(line.utf8))
+            XCTAssertFalse(record.text.isEmpty)
+        }
+    }
+
+    // MARK: - Negative / Boundary
+
+    func testAppendWithoutStartSession() async {
+        await store.appendRecord(
+            SessionRecord(speaker: .you, text: "Test", timestamp: Date())
+        )
+    }
+
+    func testEndSessionTwice() async {
+        await store.startSession()
+        await store.endSession()
+        await store.endSession()
+    }
+
+    func testAppendAfterEndSession() async {
+        await store.startSession()
+        await store.endSession()
+        await store.appendRecord(
+            SessionRecord(speaker: .you, text: "Test", timestamp: Date())
+        )
+    }
+}

--- a/Tome/Tests/TomeTests/TranscriptLoggerTests.swift
+++ b/Tome/Tests/TomeTests/TranscriptLoggerTests.swift
@@ -1,0 +1,226 @@
+import XCTest
+@testable import Tome
+
+final class TranscriptLoggerTests: XCTestCase {
+    private var tmpDir: URL!
+    private var logger: TranscriptLogger!
+
+    override func setUp() {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TomeTests-\(UUID().uuidString)")
+        logger = TranscriptLogger()
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    private func findTranscriptFile() throws -> URL {
+        let files = try FileManager.default.contentsOfDirectory(
+            at: tmpDir, includingPropertiesForKeys: nil
+        )
+        return try XCTUnwrap(
+            files.first { $0.pathExtension == "md" && !$0.lastPathComponent.hasPrefix(".") }
+        )
+    }
+
+    // MARK: - Session Creation
+
+    func testStartSessionCreatesFile() async throws {
+        try await logger.startSession(sourceApp: "TestApp", vaultPath: tmpDir.path)
+
+        let file = try findTranscriptFile()
+        XCTAssertEqual(file.pathExtension, "md")
+
+        let content = try String(contentsOf: file, encoding: .utf8)
+        XCTAssertTrue(content.hasPrefix("---\n"))
+        XCTAssertTrue(content.contains("created:"))
+        XCTAssertTrue(content.contains("time:"))
+        XCTAssertTrue(content.contains("source_app: \"TestApp\""))
+        XCTAssertTrue(content.contains("duration: \"00:00\""))
+        XCTAssertTrue(content.contains("tags:"))
+        XCTAssertTrue(content.contains("## Transcript"))
+    }
+
+    func testStartSessionCallCapture() async throws {
+        try await logger.startSession(
+            sourceApp: "Zoom", vaultPath: tmpDir.path, sessionType: .callCapture
+        )
+        let content = try String(contentsOf: try findTranscriptFile(), encoding: .utf8)
+        XCTAssertTrue(content.contains("type: meeting"))
+        XCTAssertTrue(content.contains("log/meeting"))
+        XCTAssertTrue(content.contains("source/meeting"))
+
+        let file = try findTranscriptFile()
+        XCTAssertTrue(file.lastPathComponent.contains("Call Recording"))
+    }
+
+    func testStartSessionVoiceMemo() async throws {
+        try await logger.startSession(
+            sourceApp: "Tome", vaultPath: tmpDir.path, sessionType: .voiceMemo
+        )
+        let content = try String(contentsOf: try findTranscriptFile(), encoding: .utf8)
+        XCTAssertTrue(content.contains("type: fleeting"))
+        XCTAssertTrue(content.contains("log/voice"))
+        XCTAssertTrue(content.contains("source/voice"))
+
+        let file = try findTranscriptFile()
+        XCTAssertTrue(file.lastPathComponent.contains("Voice Memo"))
+    }
+
+    // MARK: - Append
+
+    func testAppendWritesUtterances() async throws {
+        try await logger.startSession(sourceApp: "TestApp", vaultPath: tmpDir.path)
+        let now = Date()
+        await logger.append(speaker: "You", text: "Hello from me", timestamp: now)
+        await logger.append(
+            speaker: "Them", text: "Hello from them",
+            timestamp: now.addingTimeInterval(5)
+        )
+        await logger.endSession()
+
+        let content = try String(contentsOf: try findTranscriptFile(), encoding: .utf8)
+        XCTAssertTrue(content.contains("**You**"))
+        XCTAssertTrue(content.contains("Hello from me"))
+        // labelForSpeaker converts "Them" → "Speaker 2"
+        XCTAssertTrue(content.contains("**Speaker 2**"))
+        XCTAssertTrue(content.contains("Hello from them"))
+    }
+
+    // MARK: - Diarization
+
+    func testRewriteWithDiarization() async throws {
+        let approxStart = Date()
+        try await logger.startSession(sourceApp: "TestApp", vaultPath: tmpDir.path)
+        await logger.endSession()
+
+        // Inject "Them" entries into the file for diarization to process
+        let file = try findTranscriptFile()
+        var content = try String(contentsOf: file, encoding: .utf8)
+
+        let timeFmt = DateFormatter()
+        timeFmt.dateFormat = "HH:mm:ss"
+        let ts1 = timeFmt.string(from: approxStart.addingTimeInterval(5))
+        let ts2 = timeFmt.string(from: approxStart.addingTimeInterval(15))
+
+        content += "**Them** (\(ts1))\nFirst utterance\n\n"
+        content += "**Them** (\(ts2))\nSecond utterance\n\n"
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        await logger.rewriteWithDiarization(segments: [
+            (speakerId: "spk_A", startTime: 0, endTime: 10),
+            (speakerId: "spk_B", startTime: 10, endTime: 20),
+        ])
+
+        let result = try String(contentsOf: file, encoding: .utf8)
+        XCTAssertTrue(result.contains("**Speaker 2**"))
+        XCTAssertTrue(result.contains("**Speaker 3**"))
+        XCTAssertFalse(result.contains("**Them**"))
+        XCTAssertTrue(result.contains("First utterance"))
+        XCTAssertTrue(result.contains("Second utterance"))
+        XCTAssertTrue(result.contains("**Speakers:** 3"))
+    }
+
+    func testRewriteWithEmptySegments() async throws {
+        try await logger.startSession(sourceApp: "TestApp", vaultPath: tmpDir.path)
+        await logger.append(speaker: "You", text: "Hello", timestamp: Date())
+        await logger.endSession()
+
+        let file = try findTranscriptFile()
+        let contentBefore = try String(contentsOf: file, encoding: .utf8)
+
+        await logger.rewriteWithDiarization(segments: [])
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+        let contentAfter = try String(contentsOf: file, encoding: .utf8)
+        XCTAssertTrue(contentAfter.contains("Hello"))
+        // Empty segments → diarSpeakerMap is empty → allSpeakers = {"You"} → count = 1
+        XCTAssertTrue(contentAfter.contains("**Speakers:** 1"))
+    }
+
+    func testRewriteWithNoSession() async {
+        await logger.rewriteWithDiarization(segments: [
+            (speakerId: "spk_A", startTime: 0, endTime: 10),
+        ])
+    }
+
+    // MARK: - Finalize Frontmatter
+
+    func testFinalizeFrontmatter() async throws {
+        try await logger.startSession(sourceApp: "TestApp", vaultPath: tmpDir.path)
+        await logger.append(speaker: "You", text: "Hello", timestamp: Date())
+        await logger.append(speaker: "Them", text: "Reply", timestamp: Date())
+        await logger.endSession()
+
+        let result = await logger.finalizeFrontmatter()
+        XCTAssertNotNil(result)
+
+        let content = try String(contentsOf: result!, encoding: .utf8)
+        XCTAssertTrue(content.contains("\"Speaker 2\""))
+        XCTAssertTrue(content.contains("\"You\""))
+        XCTAssertTrue(content.contains("**Speakers:** 2"))
+        XCTAssertNotNil(
+            content.range(of: #"duration: "\d{2}:\d{2}""#, options: .regularExpression)
+        )
+    }
+
+    func testFinalizeFrontmatterRenamesFile() async throws {
+        try await logger.startSession(sourceApp: "TestApp", vaultPath: tmpDir.path)
+        await logger.updateContext("Important Meeting")
+        await logger.endSession()
+
+        let result = await logger.finalizeFrontmatter()
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.lastPathComponent.contains("Important Meeting"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result!.path))
+
+        let files = try FileManager.default.contentsOfDirectory(
+            at: tmpDir, includingPropertiesForKeys: nil
+        )
+        let mdFiles = files.filter {
+            $0.pathExtension == "md" && !$0.lastPathComponent.hasPrefix(".")
+        }
+        XCTAssertEqual(mdFiles.count, 1)
+    }
+
+    func testFinalizeFrontmatterNoSession() async {
+        let result = await logger.finalizeFrontmatter()
+        XCTAssertNil(result)
+    }
+
+    // MARK: - End Session
+
+    func testEndSessionTwice() async throws {
+        try await logger.startSession(sourceApp: "TestApp", vaultPath: tmpDir.path)
+        await logger.endSession()
+        await logger.endSession()
+    }
+
+    // MARK: - Full Flow
+
+    func testFullFlow() async throws {
+        try await logger.startSession(
+            sourceApp: "Zoom", vaultPath: tmpDir.path, sessionType: .callCapture
+        )
+        let now = Date()
+        await logger.append(speaker: "You", text: "Hello everyone", timestamp: now)
+        await logger.append(
+            speaker: "Them", text: "Hi there",
+            timestamp: now.addingTimeInterval(3)
+        )
+        await logger.updateContext("Weekly Standup")
+        await logger.endSession()
+
+        let finalPath = await logger.finalizeFrontmatter()
+        XCTAssertNotNil(finalPath)
+
+        let content = try String(contentsOf: finalPath!, encoding: .utf8)
+        XCTAssertTrue(content.contains("source_app: \"Zoom\""))
+        XCTAssertTrue(content.contains("type: meeting"))
+        XCTAssertTrue(content.contains("Hello everyone"))
+        XCTAssertTrue(content.contains("Hi there"))
+        XCTAssertTrue(content.contains("Weekly Standup"))
+        XCTAssertTrue(finalPath!.lastPathComponent.contains("Weekly Standup"))
+    }
+}

--- a/Tome/Tests/TomeTests/TranscriptStoreTests.swift
+++ b/Tome/Tests/TomeTests/TranscriptStoreTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Tome
+
+@MainActor
+final class TranscriptStoreTests: XCTestCase {
+
+    func testAppend() {
+        let store = TranscriptStore()
+        let utterance = Utterance(text: "Hello", speaker: .you)
+        store.append(utterance)
+
+        XCTAssertEqual(store.utterances.count, 1)
+        XCTAssertEqual(store.utterances[0].text, "Hello")
+        XCTAssertNotNil(store.lastUtteranceTimestamp)
+    }
+
+    func testAppendPreservesOrder() {
+        let store = TranscriptStore()
+        store.append(Utterance(text: "First", speaker: .you))
+        store.append(Utterance(text: "Second", speaker: .them))
+        store.append(Utterance(text: "Third", speaker: .you))
+
+        XCTAssertEqual(store.utterances.map(\.text), ["First", "Second", "Third"])
+    }
+
+    func testClear() {
+        let store = TranscriptStore()
+        store.append(Utterance(text: "Hello", speaker: .you))
+        store.clear()
+
+        XCTAssertTrue(store.utterances.isEmpty)
+        XCTAssertNil(store.lastUtteranceTimestamp)
+    }
+
+    func testClearOnEmpty() {
+        let store = TranscriptStore()
+        store.clear()
+        XCTAssertTrue(store.utterances.isEmpty)
+    }
+
+    func testClearResetsVolatileText() {
+        let store = TranscriptStore()
+        store.volatileYouText = "typing..."
+        store.volatileThemText = "speaking..."
+        store.clear()
+
+        XCTAssertEqual(store.volatileYouText, "")
+        XCTAssertEqual(store.volatileThemText, "")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TomeTests` test target to Package.swift with 29 tests across 4 test files
- **TranscriptLoggerTests** (12): session creation, append, diarization rewrite, frontmatter finalization with file rename, full end-to-end flow
- **ModelsTests** (7): Speaker/Utterance/SessionRecord Codable round-trips, invalid input rejection
- **TranscriptStoreTests** (5): append ordering, clear state, volatile text reset
- **SessionStoreTests** (5): JSONL file creation, record encoding, no-crash boundary cases

All tests run against real temp-directory files without requiring FluidAudio models or audio hardware.

## Test plan
- [x] `swift test` passes: 29 tests, 0 failures
- [ ] Verify CI builds the test target and runs tests