### PR TITLE
Fix appcast MIME type for Sparkle updates

### DIFF
--- a/.github/workflows/release-dmg.yml
+++ b/.github/workflows/release-dmg.yml
@@ -159,7 +159,7 @@ jobs:
                 <enclosure url="${DMG_URL}"
                            sparkle:edSignature="${ED_SIGNATURE}"
                            length="${DMG_LENGTH}"
-                           type="application/octet-stream" />
+                           type="application/x-apple-diskimage" />
               </item>
             </channel>
           </rss>


### PR DESCRIPTION
## Summary
- Changed appcast enclosure type from `application/octet-stream` to `application/x-apple-diskimage`
- This fixes Sparkle update failures — Sparkle needs the correct MIME type to mount the downloaded DMG

## Impact
**This affects all Tome users.** Every release built with this workflow has the wrong MIME type in the appcast, so Sparkle auto-updates fail for everyone — not just a single machine. Users who installed from a direct DMG download are fine initially but will never receive a successful auto-update.

## After merging
The live appcast on `gh-pages` still has the old MIME type, so updates for 1.2.2 will continue to fail until you either:
1. Re-run the release workflow for 1.2.2, or
2. Manually edit `appcast.xml` on the `gh-pages` branch (change `application/octet-stream` to `application/x-apple-diskimage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)