### PR TITLE
Add auto-start/stop transcription on meeting detection

### DIFF
--- a/Tome/Sources/Tome/Audio/MeetingDetector.swift
+++ b/Tome/Sources/Tome/Audio/MeetingDetector.swift
@@ -1,0 +1,180 @@
+import CoreAudio
+import AppKit
+import Observation
+
+/// Monitors the system default input device's "is running" property to detect
+/// when another app (e.g. Teams) starts using the microphone, then checks if
+/// a known conferencing app is running.
+@Observable
+@MainActor
+final class MeetingDetector {
+    private(set) var detectedApp: (bundleID: String, name: String)?
+
+    private var listenerBlock: AudioObjectPropertyListenerBlock?
+    private var stopDebounceTask: Task<Void, Never>?
+    private var isInstalled = false
+
+    /// How long to wait after the mic is released before signaling stop (seconds).
+    private let stopDelay: UInt64 = 20
+
+    private let conferencingBundleIDs: [String: String] = [
+        "com.microsoft.teams2": "Teams",
+        "com.microsoft.teams": "Teams",
+        "us.zoom.xos": "Zoom",
+        "com.apple.FaceTime": "FaceTime",
+        "com.tinyspeck.slackmacgap": "Slack",
+        "com.cisco.webexmeetingsapp": "Webex",
+        "Cisco-Systems.Spark": "Webex",
+        "com.google.Chrome": "Chrome",
+        "company.thebrowser.Browser": "Arc",
+        "com.apple.Safari": "Safari",
+        "com.microsoft.edgemac": "Edge",
+    ]
+
+    var onMeetingStarted: ((String, String) -> Void)?  // (bundleID, appName)
+    var onMeetingStopped: (() -> Void)?
+
+    func install() {
+        guard !isInstalled else { return }
+        isInstalled = true
+
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            Task { @MainActor in
+                self?.handleMicRunningChange()
+            }
+        }
+        listenerBlock = block
+
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        // Listen on default input device
+        guard let deviceID = defaultInputDeviceID() else { return }
+        AudioObjectAddPropertyListenerBlock(deviceID, &address, DispatchQueue.main, block)
+
+        // Also listen for default device changes so we can re-attach
+        var defaultDeviceAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let deviceChangeBlock: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            Task { @MainActor in
+                self?.reattachListener()
+            }
+        }
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &defaultDeviceAddress,
+            DispatchQueue.main,
+            deviceChangeBlock
+        )
+    }
+
+    func uninstall() {
+        guard isInstalled, let block = listenerBlock else { return }
+        isInstalled = false
+        stopDebounceTask?.cancel()
+
+        if let deviceID = defaultInputDeviceID() {
+            var address = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectRemovePropertyListenerBlock(deviceID, &address, DispatchQueue.main, block)
+        }
+        listenerBlock = nil
+    }
+
+    // MARK: - Private
+
+    private func handleMicRunningChange() {
+        let micInUse = isMicRunning()
+        diagLog("[MEETING-DETECT] mic running = \(micInUse)")
+
+        if micInUse {
+            stopDebounceTask?.cancel()
+            stopDebounceTask = nil
+
+            // Already tracking a meeting
+            guard detectedApp == nil else { return }
+
+            // Check if a conferencing app is running
+            if let app = findRunningConferencingApp() {
+                diagLog("[MEETING-DETECT] detected conferencing app: \(app.name) (\(app.bundleID))")
+                detectedApp = app
+                onMeetingStarted?(app.bundleID, app.name)
+            }
+        } else {
+            // Mic released — debounce before signaling stop
+            guard detectedApp != nil else { return }
+            stopDebounceTask?.cancel()
+            stopDebounceTask = Task {
+                try? await Task.sleep(for: .seconds(stopDelay))
+                guard !Task.isCancelled else { return }
+                // Re-check: mic might have resumed (e.g. brief mute)
+                if !self.isMicRunning() {
+                    diagLog("[MEETING-DETECT] mic still off after delay, stopping session")
+                    self.detectedApp = nil
+                    self.onMeetingStopped?()
+                }
+            }
+        }
+    }
+
+    private func findRunningConferencingApp() -> (bundleID: String, name: String)? {
+        for app in NSWorkspace.shared.runningApplications {
+            guard let bundleID = app.bundleIdentifier,
+                  let name = conferencingBundleIDs[bundleID] else { continue }
+            return (bundleID, name)
+        }
+        return nil
+    }
+
+    private func isMicRunning() -> Bool {
+        guard let deviceID = defaultInputDeviceID() else { return false }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var isRunning: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &isRunning)
+        return status == noErr && isRunning != 0
+    }
+
+    private func defaultInputDeviceID() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID: AudioDeviceID = 0
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address, 0, nil, &size, &deviceID
+        )
+        return status == noErr ? deviceID : nil
+    }
+
+    private func reattachListener() {
+        guard isInstalled, let block = listenerBlock else { return }
+        // Remove from old device (best-effort, may fail if device gone)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        // Re-attach to new default device
+        if let deviceID = defaultInputDeviceID() {
+            AudioObjectAddPropertyListenerBlock(deviceID, &address, DispatchQueue.main, block)
+            diagLog("[MEETING-DETECT] reattached listener to device \(deviceID)")
+        }
+    }
+}

--- a/Tome/Sources/Tome/Settings/AppSettings.swift
+++ b/Tome/Sources/Tome/Settings/AppSettings.swift
@@ -28,6 +28,11 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(vaultVoicePath, forKey: "vaultVoicePath") }
     }
 
+    /// When true, automatically starts transcription when a conferencing app uses the mic.
+    var autoStartEnabled: Bool {
+        didSet { UserDefaults.standard.set(autoStartEnabled, forKey: "autoStartEnabled") }
+    }
+
     /// When true, all app windows are invisible to screen sharing / recording.
     var hideFromScreenShare: Bool {
         didSet {
@@ -42,6 +47,7 @@ final class AppSettings {
         self.inputDeviceID = AudioDeviceID(defaults.integer(forKey: "inputDeviceID"))
         self.vaultMeetingsPath = defaults.string(forKey: "vaultMeetingsPath") ?? NSString("~/Documents/Tome/Meetings").expandingTildeInPath
         self.vaultVoicePath = defaults.string(forKey: "vaultVoicePath") ?? NSString("~/Documents/Tome/Voice").expandingTildeInPath
+        self.autoStartEnabled = defaults.bool(forKey: "autoStartEnabled")
         // Default to true (hidden) if key has never been set
         if defaults.object(forKey: "hideFromScreenShare") == nil {
             self.hideFromScreenShare = true

--- a/Tome/Sources/Tome/Views/ContentView.swift
+++ b/Tome/Sources/Tome/Views/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
     @State private var savedFileURL: URL?
     @State private var bannerDismissTask: Task<Void, Never>?
     @State private var sessionElapsed: Int = 0
+    @State private var meetingDetector = MeetingDetector()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -135,6 +136,20 @@ struct ContentView: View {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(10))
                 await transcriptLogger.flushIfNeeded()
+            }
+        }
+        // Auto-start meeting detection
+        .task {
+            setupMeetingDetector()
+            if settings.autoStartEnabled {
+                meetingDetector.install()
+            }
+        }
+        .onChange(of: settings.autoStartEnabled) {
+            if settings.autoStartEnabled {
+                meetingDetector.install()
+            } else {
+                meetingDetector.uninstall()
             }
         }
         .onChange(of: settings.inputDeviceID) {
@@ -248,6 +263,53 @@ struct ContentView: View {
 
     private func formatTime(_ s: Int) -> String {
         "\(s / 60):\(String(format: "%02d", s % 60))"
+    }
+
+    // MARK: - Meeting Detection
+
+    private func setupMeetingDetector() {
+        meetingDetector.onMeetingStarted = { bundleID, appName in
+            guard !isRunning else { return }
+            diagLog("[AUTO-START] starting session for \(appName)")
+            startSession(appBundleID: bundleID, appName: appName)
+        }
+        meetingDetector.onMeetingStopped = {
+            guard isRunning, activeSessionType == .callCapture else { return }
+            diagLog("[AUTO-STOP] stopping session")
+            stopSession()
+        }
+    }
+
+    /// Auto-start variant: called by MeetingDetector with a known conferencing app.
+    private func startSession(appBundleID: String, appName: String) {
+        transcriptStore.clear()
+        silenceSeconds = 0
+        sessionElapsed = 0
+        savedFileURL = nil
+        bannerDismissTask?.cancel()
+
+        Task {
+            transcriptionEngine?.lastError = nil
+            await sessionStore.startSession()
+            do {
+                try await transcriptLogger.startSession(
+                    sourceApp: appName,
+                    vaultPath: settings.vaultMeetingsPath,
+                    sessionType: .callCapture
+                )
+            } catch {
+                await sessionStore.endSession()
+                transcriptionEngine?.lastError = error.localizedDescription
+                return
+            }
+            activeSessionType = .callCapture
+            detectedAppName = appName
+            await transcriptionEngine?.start(
+                locale: settings.locale,
+                inputDeviceID: settings.inputDeviceID,
+                appBundleID: appBundleID
+            )
+        }
     }
 
     // MARK: - Actions

--- a/Tome/Sources/Tome/Views/SettingsView.swift
+++ b/Tome/Sources/Tome/Views/SettingsView.swift
@@ -61,6 +61,14 @@ struct SettingsView: View {
                 .font(.system(size: 12))
             }
 
+            Section("Automation") {
+                Toggle("Auto-start on meeting", isOn: $settings.autoStartEnabled)
+                    .font(.system(size: 12))
+                Text("Automatically starts transcription when a conferencing app (Teams, Zoom, etc.) uses the microphone, and stops when the call ends.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Privacy") {
                 Toggle("Hide from screen sharing", isOn: $settings.hideFromScreenShare)
                     .font(.system(size: 12))
@@ -78,7 +86,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 450, height: 420)
+        .frame(width: 450, height: 500)
         .onAppear {
             inputDevices = MicCapture.availableInputDevices()
         }


### PR DESCRIPTION
## Summary

- Adds a `MeetingDetector` that monitors the system microphone via CoreAudio (`kAudioDevicePropertyDeviceIsRunningSomewhere`) to detect when a conferencing app starts a call
- Automatically begins call capture when a known app (Teams, Zoom, FaceTime, Slack, Webex, Chrome, Arc, Safari, Edge) activates the mic
- Automatically stops transcription after a 20-second debounce when the mic is released (avoids false stops from brief mutes)
- New "Auto-start on meeting" toggle in Settings (disabled by default)
- Re-attaches the listener automatically when the default input device changes

## Files changed

- **New**: `Audio/MeetingDetector.swift` — CoreAudio listener + conferencing app detection
- **Modified**: `Settings/AppSettings.swift` — new `autoStartEnabled` preference
- **Modified**: `Views/SettingsView.swift` — new Automation section with toggle
- **Modified**: `Views/ContentView.swift` — detector setup, callbacks, auto-start session variant

## Test plan

- [ ] Enable toggle in Settings, join a Teams/Zoom call → transcription should start automatically
- [ ] End the call → transcription should stop after ~20 seconds
- [ ] Mute/unmute during a call → transcription should NOT stop
- [ ] Manual start/stop should still work independently
- [ ] Toggle disabled → no automatic behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)