### PR TITLE
Fix mic capture on devices where hardware sample rate differs from AVAudioEngine output format

### DIFF
--- a/Tome/Sources/Tome/Audio/MicCapture.swift
+++ b/Tome/Sources/Tome/Audio/MicCapture.swift
@@ -38,7 +38,7 @@ final class MicCapture: @unchecked Sendable {
             }
 
             let inputNode = self.engine.inputNode
-            let format = inputNode.outputFormat(forBus: 0)
+            let format = inputNode.inputFormat(forBus: 0)
 
             diagLog("[MIC-3] inputNode format: sr=\(format.sampleRate) ch=\(format.channelCount) interleaved=\(format.isInterleaved) commonFormat=\(format.commonFormat.rawValue)")
 


### PR DESCRIPTION
Fixes #27

## Summary

One-line fix in `MicCapture.swift`: use `inputNode.inputFormat(forBus: 0)` instead of `inputNode.outputFormat(forBus: 0)` when building the tap format.

On a MacBook Air (Apple Silicon, macOS 26) with the built-in mic running at 96kHz hardware sample rate, `outputFormat(forBus: 0)` reports 48kHz. Installing a tap with that mismatched format causes `AVAudioEngine` to silently drop every buffer — no error, `isRunning = true`, tap callback never fires. Result: mic audio is never captured, meter stays at zero, and transcripts come out empty (Voice Memo entirely blank, Call Capture only captures the remote side).

`inputFormat(forBus: 0)` returns the true hardware format. The downstream resampler in `StreamingTranscriber.extractSamples()` already handles arbitrary input rates via `AVAudioConverter`, so no other changes are needed.

Verified via a standalone Swift test on the affected machine before and after the change:

- Before (`outputFormat`, 48kHz): 0 buffers in 2s, maxRMS = 0
- After  (`inputFormat`,  96kHz): 20 buffers in 2s, maxRMS ≈ 0.005, real audio

Also verified end-to-end: built from source, ad-hoc signed, installed to /Applications. Voice Memo and Call Capture both now transcribe the user's voice correctly.

See #27 for the full investigation.

## Test plan

- [ ] Build on Apple Silicon with `./scripts/build_swift_app.sh`
- [ ] Voice Memo: speak for ~10s, confirm transcript contains user audio
- [ ] Call Capture: join a call, speak, confirm both "You" and remote speaker segments appear
- [ ] Devices with hardware rate == 48kHz should continue to work unchanged (formats match either way)