### PR TITLE
Fix call-start audio contention and per-call memory ratchet

### DIFF
--- a/.github/workflows/release-dmg.yml
+++ b/.github/workflows/release-dmg.yml
@@ -138,6 +138,15 @@ jobs:
           echo "EdDSA signature: $ED_SIGNATURE"
           echo "DMG length: $DMG_LENGTH"
 
+          # Refuse to publish an appcast the shipped app would reject. If the
+          # SPARKLE_EDDSA_KEY secret is not the private counterpart of the
+          # SUPublicEDKey in Info.plist, every install fails the update with
+          # "The update is improperly signed" — fail the release here instead.
+          python3 -m pip install --quiet cryptography || true
+          PUB_KEY=$(/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Detto/Sources/Detto/Info.plist")
+          chmod +x scripts/verify_sparkle_signature.sh
+          ./scripts/verify_sparkle_signature.sh "$DMG_PATH" "$ED_SIGNATURE" "$PUB_KEY"
+
           DMG_URL="https://github.com/Gremble-io/detto/releases/download/${TAG}/Detto.dmg"
           PUB_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S %z")
 

--- a/Detto/Package.swift
+++ b/Detto/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Detto",
     platforms: [.macOS(.v26)],
     dependencies: [
-        .package(url: "https://github.com/Gremble-io/gremble-voice.git", revision: "139cea97f6a89a8d5c86556c93527db2efa39a8c"),
+        .package(url: "https://github.com/Gremble-io/gremble-voice.git", revision: "149889c1efcad7a08c389f3350d4abdbf2df8de3"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
     ],
     targets: [

--- a/Detto/Sources/Detto/App/DettoApp.swift
+++ b/Detto/Sources/Detto/App/DettoApp.swift
@@ -1,23 +1,38 @@
 import SwiftUI
 import AppKit
 import Sparkle
+import GrembleVoiceParakeet
+import GrembleVoiceRefinement
 
 @main
 struct DettoApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @State private var settings = AppSettings()
-    @State private var dictationController = DictationController()
+    @State private var dictationController: DictationController
     @State private var menuBarAnimator: MenuBarAnimator?
     private let updaterController = AppUpdaterController()
+
+    /// Single Parakeet model manager shared by dictation and meeting
+    /// transcription so the ASR model is loaded into memory once.
+    private let sharedASRManager: ParakeetModelManager
 
     init() {
         DettoTheme.registerFonts()
         TranscriptionEngine.cleanupOrphanedAudioFiles()
+
+        // Bound MLX's Metal buffer cache. Without a limit, freed buffers from
+        // each refinement pass stay resident and wired memory ratchets upward
+        // across calls.
+        MLXMemory.setCacheLimit(megabytes: 512)
+
+        let manager = ParakeetModelManager()
+        sharedASRManager = manager
+        _dictationController = State(initialValue: DictationController(asrManager: manager))
     }
 
     var body: some Scene {
         WindowGroup {
-            ContentView(settings: settings, dictationController: dictationController)
+            ContentView(settings: settings, dictationController: dictationController, asrManager: sharedASRManager)
                 .id(settings.darkMode)
                 .onAppear {
                     settings.applyScreenShareVisibility()

--- a/Detto/Sources/Detto/Audio/MicCapture.swift
+++ b/Detto/Sources/Detto/Audio/MicCapture.swift
@@ -265,6 +265,32 @@ final class MicCapture: @unchecked Sendable {
         return status == noErr ? uid as String : nil
     }
 
+    /// CoreAudio transport type for a device (e.g. Bluetooth, built-in), or nil.
+    static func transportType(for deviceID: AudioDeviceID) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var transport: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transport)
+        return status == noErr ? transport : nil
+    }
+
+    static func isBluetoothDevice(_ deviceID: AudioDeviceID) -> Bool {
+        guard let transport = transportType(for: deviceID) else { return false }
+        return transport == kAudioDeviceTransportTypeBluetooth
+            || transport == kAudioDeviceTransportTypeBluetoothLE
+    }
+
+    /// The built-in microphone's device ID, if this Mac has one.
+    static func builtInInputDeviceID() -> AudioDeviceID? {
+        availableInputDevices().first {
+            transportType(for: $0.id) == kAudioDeviceTransportTypeBuiltIn
+        }?.id
+    }
+
     static func defaultInputDeviceID() -> AudioDeviceID? {
         var propertyAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultInputDevice,

--- a/Detto/Sources/Detto/Dictation/DictationController.swift
+++ b/Detto/Sources/Detto/Dictation/DictationController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import GrembleVoiceCore
 import GrembleVoiceEngine
+import GrembleVoiceParakeet
 
 @MainActor
 final class DictationController {
@@ -36,8 +37,13 @@ final class DictationController {
 
     // MARK: - Init
 
-    init() {
-        pipeline = GrembleVoicePipeline(config: DictationController.makeConfig())
+    /// - Parameter asrManager: Shared Parakeet manager so dictation and meeting
+    ///   transcription use one loaded copy of the ASR model.
+    init(asrManager: ParakeetModelManager? = nil) {
+        pipeline = GrembleVoicePipeline(
+            config: DictationController.makeConfig(),
+            sharedParakeetManager: asrManager
+        )
     }
 
     // MARK: - Config

--- a/Detto/Sources/Detto/Settings/AppSettings.swift
+++ b/Detto/Sources/Detto/Settings/AppSettings.swift
@@ -23,6 +23,13 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(Int(inputDeviceID), forKey: "inputDeviceID") }
     }
 
+    /// During call capture on the system-default input, swap a Bluetooth
+    /// default mic for the built-in mic so Detto doesn't contend with the
+    /// conferencing app over the headset's HFP profile.
+    var preferBuiltInMicDuringCalls: Bool {
+        didSet { UserDefaults.standard.set(preferBuiltInMicDuringCalls, forKey: "preferBuiltInMicDuringCalls") }
+    }
+
     var vaultMeetingsPath: String {
         didSet { UserDefaults.standard.set(vaultMeetingsPath, forKey: "vaultMeetingsPath") }
     }
@@ -83,6 +90,7 @@ final class AppSettings {
         let defaults = UserDefaults.standard
         self.transcriptionLocale = defaults.string(forKey: "transcriptionLocale") ?? "en-US"
         self.inputDeviceID = AudioDeviceID(defaults.integer(forKey: "inputDeviceID"))
+        self.preferBuiltInMicDuringCalls = defaults.object(forKey: "preferBuiltInMicDuringCalls") as? Bool ?? true
         self.vaultMeetingsPath = defaults.string(forKey: "vaultMeetingsPath") ?? NSString("~/Documents/Detto/Meetings").expandingTildeInPath
         self.vaultVoicePath = defaults.string(forKey: "vaultVoicePath") ?? NSString("~/Documents/Detto/Voice").expandingTildeInPath
         self.vaultRootPath = defaults.string(forKey: "vaultRootPath") ?? ""

--- a/Detto/Sources/Detto/Transcription/PostSessionRefiner.swift
+++ b/Detto/Sources/Detto/Transcription/PostSessionRefiner.swift
@@ -20,17 +20,36 @@ struct PostSessionRefiner {
         - Output only the corrected text, nothing else.
         """
 
-    static func refine(_ utterances: [Utterance]) async -> [Correction] {
+    /// Refine utterances with the on-device LLM.
+    ///
+    /// Pass the app's resident refiner (the dictation pipeline's) via
+    /// `reusing:` so the already-loaded model is used instead of loading a
+    /// second ~1.8 GB copy. A borrowed refiner is never unloaded here. Only
+    /// when no refiner is supplied does this fall back to a temporary
+    /// load/unload cycle.
+    static func refine(
+        _ utterances: [Utterance],
+        reusing residentRefiner: PrefillMLXRefiner? = nil
+    ) async -> [Correction] {
         guard !utterances.isEmpty else { return [] }
 
         engineLog("[REFINE] Starting post-session refinement for \(utterances.count) utterances")
 
-        let refiner = PrefillMLXRefiner()
-        do {
-            try await refiner.loadModel()
-        } catch {
-            engineLog("[REFINE] Model not available, skipping refinement: \(error.localizedDescription)")
-            return []
+        let refiner: PrefillMLXRefiner
+        let ownsRefiner: Bool
+        if let residentRefiner, await residentRefiner.isModelLoaded {
+            engineLog("[REFINE] Reusing resident MLX refiner")
+            refiner = residentRefiner
+            ownsRefiner = false
+        } else {
+            refiner = PrefillMLXRefiner()
+            ownsRefiner = true
+            do {
+                try await refiner.loadModel()
+            } catch {
+                engineLog("[REFINE] Model not available, skipping refinement: \(error.localizedDescription)")
+                return []
+            }
         }
 
         try? await refiner.prefill(systemPrompt: systemPrompt)
@@ -81,7 +100,12 @@ struct PostSessionRefiner {
             }
         }
 
-        await refiner.unloadModel()
+        if ownsRefiner {
+            await refiner.unloadModel()
+        }
+        // Return the batch's Metal buffers to the OS either way — post-session
+        // refinement is bursty work whose working set shouldn't stay resident.
+        MLXMemory.clearCache()
         engineLog("[REFINE] Complete: \(corrections.count)/\(utterances.count) utterances refined")
         return corrections
     }

--- a/Detto/Sources/Detto/Transcription/TranscriptionEngine.swift
+++ b/Detto/Sources/Detto/Transcription/TranscriptionEngine.swift
@@ -86,7 +86,7 @@ final class TranscriptionEngine {
     var audioLevel: Float { max(micCapture.audioLevel, systemCapture.audioLevel) }
 
     // GrembleVoice engines
-    private var modelManager: ParakeetModelManager?
+    private let modelManager: ParakeetModelManager
     private var asrEngine: ParakeetStreamingEngine?
     private var diarEngine: StreamingDiarizationEngine?
     private var offlineDiarEngine: DiarizationEngine?
@@ -117,18 +117,45 @@ final class TranscriptionEngine {
     /// Tracks whether user selected "System Default" (0) or a specific device.
     private var userSelectedDeviceID: AudioDeviceID = 0
 
+    /// When true and capturing a call on the system-default input, a Bluetooth
+    /// default input is swapped for the built-in mic to avoid contending with
+    /// the conferencing app over the headset's HFP profile.
+    private var preferBuiltInMicDuringCalls = false
+
+    /// Whether the current session captures system audio (call capture).
+    private var sessionIsCallCapture = false
+
     /// Listens for default input device changes at the OS level.
     private var defaultDeviceListenerBlock: AudioObjectPropertyListenerBlock?
 
-    init(transcriptStore: TranscriptStore) {
+    init(transcriptStore: TranscriptStore, modelManager: ParakeetModelManager) {
         self.transcriptStore = transcriptStore
+        self.modelManager = modelManager
+    }
+
+    /// Resolve which mic device to open. Returns (deviceParam, trackedID):
+    /// deviceParam is nil for "system default", trackedID is the concrete device.
+    private func resolveMicDevice(userSelected: AudioDeviceID) -> (param: AudioDeviceID?, tracked: AudioDeviceID) {
+        if userSelected > 0 {
+            return (userSelected, userSelected)
+        }
+        let systemDefault = MicCapture.defaultInputDeviceID() ?? 0
+        if preferBuiltInMicDuringCalls,
+           sessionIsCallCapture,
+           systemDefault != 0,
+           MicCapture.isBluetoothDevice(systemDefault),
+           let builtIn = MicCapture.builtInInputDeviceID() {
+            engineLog("[ENGINE-MIC-BT] Default input \(systemDefault) is Bluetooth during call capture — using built-in mic \(builtIn) instead")
+            return (builtIn, builtIn)
+        }
+        return (nil, systemDefault)
     }
 
     func preloadModels() async {
-        guard modelManager == nil else { return }
+        guard asrEngine == nil else { return }
         let preloadStart = Date()
         engineLog("[ENGINE-PRELOAD] preloading models in background...")
-        let mm = ParakeetModelManager()
+        let mm = modelManager
         let diar = StreamingDiarizationEngine(preset: .highContext)
         engineLog("[ENGINE-DIAR] Streaming preset: highContext (30000 frames)")
         let offlineDiar = DiarizationEngine()
@@ -145,7 +172,6 @@ final class TranscriptionEngine {
             async let offlineLoad: Void = offlineDiar.prepareModels()
 
             try await asrLoad
-            self.modelManager = mm
             self.asrEngine = ParakeetStreamingEngine(modelManager: mm)
 
             do {
@@ -170,10 +196,12 @@ final class TranscriptionEngine {
         }
     }
 
-    func start(locale: Locale, inputDeviceID: AudioDeviceID = 0, appBundleID: String? = nil, micOnly: Bool = false, vocabularyCorrector: VocabularyCorrector? = nil) async {
+    func start(locale: Locale, inputDeviceID: AudioDeviceID = 0, appBundleID: String? = nil, micOnly: Bool = false, preferBuiltInMic: Bool = true, vocabularyCorrector: VocabularyCorrector? = nil) async {
         engineLog("[ENGINE-0] start() called, isRunning=\(isRunning)")
         guard !isRunning else { return }
         lastError = nil
+        preferBuiltInMicDuringCalls = preferBuiltInMic
+        sessionIsCallCapture = !micOnly
 
         guard await ensureMicrophonePermission() else { return }
 
@@ -186,8 +214,8 @@ final class TranscriptionEngine {
         }
 
         // 1. Load GrembleVoice models if not already preloaded
-        if modelManager == nil {
-            let mm = ParakeetModelManager()
+        if asrEngine == nil {
+            let mm = modelManager
             let diar = StreamingDiarizationEngine(preset: .highContext)
             engineLog("[ENGINE-DIAR] Streaming preset: highContext (30000 frames)")
 
@@ -205,7 +233,6 @@ final class TranscriptionEngine {
                 async let diarLoad: Void = diar.prepareModels { _ in }
 
                 try await asrLoad
-                self.modelManager = mm
                 self.asrEngine = ParakeetStreamingEngine(modelManager: mm)
 
                 do {
@@ -233,8 +260,9 @@ final class TranscriptionEngine {
 
         // 2. Start mic capture
         userSelectedDeviceID = inputDeviceID
-        let micDeviceParam: AudioDeviceID? = inputDeviceID > 0 ? inputDeviceID : nil
-        currentMicDeviceID = inputDeviceID > 0 ? inputDeviceID : MicCapture.defaultInputDeviceID() ?? 0
+        let resolved = resolveMicDevice(userSelected: inputDeviceID)
+        let micDeviceParam = resolved.param
+        currentMicDeviceID = resolved.tracked
         engineLog("[ENGINE-3] starting mic capture, deviceParam=\(String(describing: micDeviceParam)) tracked=\(currentMicDeviceID)")
         let micStream = micCapture.bufferStream(deviceID: micDeviceParam)
         if let captureError = micCapture.captureError {
@@ -266,7 +294,6 @@ final class TranscriptionEngine {
         // 4. Start mic transcription pipeline (VADProcessor — no timing needed)
         let store = transcriptStore
         do {
-            guard let modelManager else { throw TranscriptionError.notReady }
             let micVadManager = try await modelManager.makeVadManager()
             let micVad = VADProcessor(vadManager: micVadManager)
             let micResampler = AudioBufferResampler()
@@ -364,7 +391,6 @@ final class TranscriptionEngine {
             }
 
             do {
-                guard let modelManager else { throw TranscriptionError.notReady }
                 let sysVadManager = try await modelManager.makeVadManager(threshold: 0.92)
 
                 sysLoopTask = Task.detached { [weak self] in
@@ -494,12 +520,13 @@ final class TranscriptionEngine {
 
     /// Restart only the mic capture with a new device, keeping system audio and models intact.
     func restartMic(inputDeviceID: AudioDeviceID) {
-        guard isRunning, let modelManager, let asrEngine else { return }
+        guard isRunning, let asrEngine else { return }
 
         if inputDeviceID != 0 || userSelectedDeviceID != 0 {
             userSelectedDeviceID = inputDeviceID
         }
-        let resolvedMicID = inputDeviceID > 0 ? inputDeviceID : MicCapture.defaultInputDeviceID() ?? 0
+        let resolved = resolveMicDevice(userSelected: inputDeviceID)
+        let resolvedMicID = resolved.tracked
         guard resolvedMicID != currentMicDeviceID else {
             engineLog("[ENGINE-MIC-SWAP] same device \(resolvedMicID), skipping")
             return
@@ -515,7 +542,7 @@ final class TranscriptionEngine {
 
         currentMicDeviceID = resolvedMicID
 
-        let micDeviceParam: AudioDeviceID? = inputDeviceID > 0 ? inputDeviceID : nil
+        let micDeviceParam = resolved.param
         let micStream = micCapture.bufferStream(deviceID: micDeviceParam)
         if let captureError = micCapture.captureError {
             lastError = captureError
@@ -670,9 +697,14 @@ final class TranscriptionEngine {
                     engineLog("[ENGINE-DEVICE] Selected device \(self.userSelectedDeviceID) disconnected, falling back to default")
                     self.userSelectedDeviceID = 0
                 }
+                // Wait for the device list to settle before touching the audio
+                // engine. Conferencing apps flip the default input several times
+                // in quick succession at call start; restarting mid-storm risks
+                // wedging the device (especially Bluetooth HFP negotiation).
+                // Each new change event resets this timer via the cancel above.
                 self.deviceRestartTask?.cancel()
                 self.deviceRestartTask = Task {
-                    try? await Task.sleep(for: .milliseconds(500))
+                    try? await Task.sleep(for: .seconds(3))
                     guard !Task.isCancelled else { return }
                     self.restartMic(inputDeviceID: 0)
                 }

--- a/Detto/Sources/Detto/Views/ContentView.swift
+++ b/Detto/Sources/Detto/Views/ContentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import Combine
+import GrembleVoiceParakeet
 
 private let conferencingBundleIDs: [String: String] = [
     "com.microsoft.teams2": "Teams",
@@ -19,6 +20,7 @@ private let conferencingBundleIDs: [String: String] = [
 struct ContentView: View {
     @Bindable var settings: AppSettings
     var dictationController: DictationController
+    var asrManager: ParakeetModelManager
     @State private var transcriptStore = TranscriptStore()
     @State private var transcriptionEngine: TranscriptionEngine?
     @State private var sessionStore = SessionStore()
@@ -70,7 +72,7 @@ struct ContentView: View {
                 showOnboarding = true
             }
             if transcriptionEngine == nil {
-                transcriptionEngine = TranscriptionEngine(transcriptStore: transcriptStore)
+                transcriptionEngine = TranscriptionEngine(transcriptStore: transcriptStore, modelManager: asrManager)
             }
             dictationController.isMeetingActive = { [weak transcriptionEngine] in
                 transcriptionEngine?.isRunning ?? false
@@ -551,6 +553,7 @@ struct ContentView: View {
                 locale: settings.locale,
                 inputDeviceID: settings.inputDeviceID,
                 appBundleID: appName != nil ? bundleID : nil,
+                preferBuiltInMic: settings.preferBuiltInMicDuringCalls,
                 vocabularyCorrector: corrector
             )
         }
@@ -626,6 +629,7 @@ struct ContentView: View {
                     locale: settings.locale,
                     inputDeviceID: settings.inputDeviceID,
                     appBundleID: appBundleID,
+                    preferBuiltInMic: settings.preferBuiltInMicDuringCalls,
                     vocabularyCorrector: corrector
                 )
             } else {
@@ -662,7 +666,10 @@ struct ContentView: View {
 
             if settings.enablePostSessionRefinement {
                 transcriptionEngine?.assetStatus = "Polishing transcript..."
-                let corrections = await PostSessionRefiner.refine(transcriptStore.utterances)
+                let corrections = await PostSessionRefiner.refine(
+                    transcriptStore.utterances,
+                    reusing: dictationController.pipeline.residentMLXRefiner
+                )
                 for correction in corrections {
                     transcriptStore.updateText(at: correction.index, text: correction.refined)
                 }

--- a/Detto/Sources/Detto/Views/SettingsView.swift
+++ b/Detto/Sources/Detto/Views/SettingsView.swift
@@ -18,6 +18,12 @@ struct SettingsView: View {
                     }
                 }
                 .font(.dMono(size: 12, weight: .medium))
+
+                Toggle("Prefer built-in mic during call capture", isOn: $settings.preferBuiltInMicDuringCalls)
+                    .font(.dMono(size: 12, weight: .medium))
+                Text("Avoids grabbing a Bluetooth headset mic that your call app is already using, which can drop the headset's audio.")
+                    .font(.dMono(size: 10, weight: .regular))
+                    .foregroundStyle(.secondary)
             } header: {
                 sectionHeader("AUDIO")
             }

--- a/scripts/verify_sparkle_signature.sh
+++ b/scripts/verify_sparkle_signature.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Verify a Sparkle EdDSA (Ed25519) update signature against a public key.
+#
+# Usage: verify_sparkle_signature.sh <file> <base64-signature> <base64-public-key>
+#
+# Exits 0 if the signature is valid, 1 if not. Used by the release workflow to
+# refuse to publish an appcast whose signature the shipped SUPublicEDKey would
+# reject ("The update is improperly signed"), and handy for checking a live
+# release by hand:
+#
+#   curl -sL <appcast-url>            # grab sparkle:edSignature
+#   curl -sLO <dmg-url>
+#   ./scripts/verify_sparkle_signature.sh Detto.dmg "<edSignature>" \
+#       "$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' Detto/Sources/Detto/Info.plist)"
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <file> <base64-signature> <base64-public-key>" >&2
+  exit 64
+fi
+
+python3 - "$1" "$2" "$3" <<'PY'
+import base64, os, subprocess, sys, tempfile
+
+path, sig_b64, pub_b64 = sys.argv[1:4]
+sig = base64.b64decode(sig_b64)
+pub = base64.b64decode(pub_b64)
+
+if len(pub) != 32:
+    print(f"Public key is {len(pub)} bytes after base64-decode; expected 32.")
+    sys.exit(1)
+
+def report(ok):
+    if ok:
+        print("Sparkle EdDSA signature: VALID")
+        sys.exit(0)
+    print("Sparkle EdDSA signature: INVALID — the signing key does not match this public key.")
+    print("An appcast published with this signature will fail in-app with")
+    print("\"The update is improperly signed\" on every install shipping this SUPublicEDKey.")
+    sys.exit(1)
+
+# A broken cryptography install can raise more than ImportError — treat any
+# import-time failure as "not available" and fall through to OpenSSL.
+try:
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+except BaseException:
+    InvalidSignature = None
+
+if InvalidSignature is not None:
+    try:
+        Ed25519PublicKey.from_public_bytes(pub).verify(sig, open(path, "rb").read())
+        report(True)
+    except InvalidSignature:
+        report(False)
+
+# Fallback: OpenSSL 3+ raw Ed25519 verify (Apple's bundled LibreSSL won't work;
+# on macOS install cryptography via pip or openssl@3 via brew).
+der = bytes.fromhex("302a300506032b6570032100") + pub
+with tempfile.TemporaryDirectory() as td:
+    pem = os.path.join(td, "pub.pem")
+    sigf = os.path.join(td, "sig.bin")
+    with open(pem, "w") as f:
+        f.write("-----BEGIN PUBLIC KEY-----\n")
+        f.write(base64.encodebytes(der).decode())
+        f.write("-----END PUBLIC KEY-----\n")
+    with open(sigf, "wb") as f:
+        f.write(sig)
+    r = subprocess.run(
+        ["openssl", "pkeyutl", "-verify", "-pubin", "-inkey", pem,
+         "-rawin", "-in", path, "-sigfile", sigf],
+        capture_output=True, text=True)
+    if "no supported" in (r.stderr or "").lower() or r.returncode == 64:
+        print("Neither python-cryptography nor an Ed25519-capable openssl is available.")
+        sys.exit(64)
+    report(r.returncode == 0)
+PY


### PR DESCRIPTION
## Audio — Bluetooth headsets losing audio when a call capture starts
- During call capture on the system-default input, a Bluetooth default mic is swapped for the built-in mic so Detto no longer contends with the conferencing app over the headset's HFP profile. New Settings toggle (default on) under Audio; automatic fallback on Macs without a built-in mic.
- Default-device changes now wait 3s for the device list to settle before the mic engine restarts, instead of restarting mid-negotiation while call apps flip devices at call start.

## Memory — machine slowdown after a few calls
- Dictation and meeting transcription share one `ParakeetModelManager`; the ~600 MB Parakeet model loads once instead of twice.
- Post-session refinement reuses the resident MLX refiner instead of loading a second ~1.8 GB Llama copy per call, and clears the MLX Metal buffer cache when it finishes; cache bounded to 512 MB at launch.

## Release pipeline
- `release-dmg.yml` now verifies the appcast EdDSA signature against `Info.plist`'s `SUPublicEDKey` and fails before publishing on mismatch (`scripts/verify_sparkle_signature.sh`, also usable locally). Would have caught both recent signing failures at CI time.

Depends on gremble-voice `149889c`; `Package.swift` pin bumped accordingly.